### PR TITLE
Automatic javadoc github page generation

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,46 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'zulu'
+        cache: maven
+    - name: Build with Maven
+      run: |
+        java --version
+        mvn --version
+        cd src
+        mvn site
+    - name: push site to gh-pages
+      run: |
+          git config --global user.name 'Automated User'
+          git config --global user.email 'example@sportradar.com'
+          git checkout -B gh-pages
+          mv src/target/site/apidocs .git/
+          rm -rf *
+          mv .git/apidocs/* .
+          git add .
+          git commit -am "Automated github page generation"
+          git push origin gh-pages -f

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -135,4 +135,22 @@
             </build>
         </profile>
     </profiles>
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>2.9</version>
+            </plugin>           
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.6.3</version>
+                <configuration>
+                    <nohelp>true</nohelp>
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
+
 </project>


### PR DESCRIPTION
# description

This pr will automatically generate a new documentation site and push it to gh-pages branch on every merge to main.

Resulting workflows can be seen here:
main workflow: https://github.com/zidarsk8/MbsSdkJava/actions/runs/8098650095
and gh-pages workflow: https://github.com/zidarsk8/MbsSdkJava/actions/runs/8098657777

and the resulting documentation site should look like:
https://zidarsk8.github.io/MbsSdkJava

ℹ️ 
this still requires gh pages to be enabled in the project settings.

![Screenshot 2024-02-29 at 17 06 23](https://github.com/sportradar/MbsSdkJava/assets/566311/86b008d6-3d63-4f92-82b8-e3eee54ea338)